### PR TITLE
Resolved issues with original sample app.

### DIFF
--- a/SampleApp_CPP/BarcodeDlg.cpp
+++ b/SampleApp_CPP/BarcodeDlg.cpp
@@ -409,7 +409,7 @@ void CBarcodeDlg::OnCbnSelchangeCmblang()
     
     CHECK_CMD0;
     
-    int inSel = (int) m_cmbSelectLocale.GetItemData(m_cmbSelectLocale.GetCurSel());
+    int inSel = static_cast<int>(m_cmbSelectLocale.GetItemData(m_cmbSelectLocale.GetCurSel()));
     long status = 1;
     
     SC->cmdSetKeyboardEmulatorLocale(inSel, Async, &status);

--- a/SampleApp_CPP/BarcodeDlg.h
+++ b/SampleApp_CPP/BarcodeDlg.h
@@ -52,7 +52,7 @@ private:
 	//CEdit txtRawData;
 	//CEmbeddedBrowser m_EmbeddedBrowser;
 	CBrush  m_brush;
-	bool m_bDisableEvents;
+	bool m_bDisableEvents = true;
 	
 
 	CButton m_chkEnableLocaleSelection;

--- a/SampleApp_CPP/ConfigurationDlg.cpp
+++ b/SampleApp_CPP/ConfigurationDlg.cpp
@@ -309,7 +309,7 @@ void CConfigurationDlg::UpdateClaimedStatus(int scnID)
 void CConfigurationDlg::OnChangeProtocol()
 {
 	int index = m_cmbProtocol.GetCurSel();
-	int NewProtocol = (int) m_cmbProtocol.GetItemData(index);
+	int NewProtocol = static_cast<int>(m_cmbProtocol.GetItemData(index));
 	int &CurrentProtocol = QueryScannerProtocol();
 	if(NewProtocol != CurrentProtocol)
 	{

--- a/SampleApp_CPP/EmbeddedBrowser.h
+++ b/SampleApp_CPP/EmbeddedBrowser.h
@@ -352,6 +352,7 @@ public:
 	VARIANT GetProperty(LPCTSTR Property)
 	{
 		VARIANT result;
+		VariantInit(&result);	// explicitly initialize to empty variant
 		static BYTE parms[] = VTS_BSTR ;
 		InvokeHelper(0x12f, DISPATCH_METHOD, VT_VARIANT, (void*)&result, parms, Property);
 		return result;

--- a/SampleApp_CPP/ImageVideoDlg.cpp
+++ b/SampleApp_CPP/ImageVideoDlg.cpp
@@ -101,11 +101,11 @@ void CImageVideoDlg::OnSelectJPG()
 		wstring ID;
 		wstring Value;
 
-		wchar_t buf[8];
+		wchar_t buf[_MAX_ITOSTR_BASE10_COUNT];
 		int a = 10;
-		_itow_s(IMAGE_FILETYPE_PARAMNUM, buf, 8, 10);
+		_itow_s(IMAGE_FILETYPE_PARAMNUM, buf, 10);
 		ID.append(buf);
-		_itow_s(JPEG_FILE_SELECTION, buf, 8, 10);
+		_itow_s(JPEG_FILE_SELECTION, buf, 10);
 		Value.append(buf);
 		SC->cmdSetParametersEx(SelectedScannerID, ID, Value, 0, &status);
 		LOG(status, "SET_PARAMETERS_IMAGE_JPG");
@@ -122,11 +122,11 @@ void CImageVideoDlg::OnSelectTIFF()
 		wstring ID;
 		wstring Value;
 
-		wchar_t buf[8];
+		wchar_t buf[_MAX_ITOSTR_BASE10_COUNT];
 		int a = 10;
-		_itow_s(IMAGE_FILETYPE_PARAMNUM, buf, 8, 10);
+		_itow_s(IMAGE_FILETYPE_PARAMNUM, buf, 10);
 		ID.append(buf);
-		_itow_s(TIFF_FILE_SELECTION, buf, 8, 10);
+		_itow_s(TIFF_FILE_SELECTION, buf, 10);
 		Value.append(buf);
 		SC->cmdSetParametersEx(SelectedScannerID, ID, Value, 0, &status);
 		LOG(status, "SET_PARAMETERS_IMAGE_TIFF");
@@ -143,11 +143,11 @@ void CImageVideoDlg::OnSelectBMP()
 		wstring ID;
 		wstring Value;
 
-		wchar_t buf[8];
+		wchar_t buf[_MAX_ITOSTR_BASE10_COUNT];
 		int a = 10;
-		_itow_s(IMAGE_FILETYPE_PARAMNUM, buf, 8, 10);
+		_itow_s(IMAGE_FILETYPE_PARAMNUM, buf, 10);
 		ID.append(buf);
-		_itow_s(BMP_FILE_SELECTION, buf, 8, 10);
+		_itow_s(BMP_FILE_SELECTION, buf, 10);
 		Value.append(buf);
 		SC->cmdSetParametersEx(SelectedScannerID, ID, Value, 0, &status);
 		LOG(status, "SET_PARAMETERS_IMAGE_BMP");
@@ -158,9 +158,6 @@ BOOL CImageVideoDlg::OnInitDialog()
 {
 	CDialog::OnInitDialog();
 	m_RenderEngine.Attach(m_PicControl);
-#ifdef _DEBUG
-	_CrtSetBreakAlloc(6021);  // Set break allocation for debugging
-#endif
 	return TRUE; 
 }
 

--- a/SampleApp_CPP/ImageVideoDlg.cpp
+++ b/SampleApp_CPP/ImageVideoDlg.cpp
@@ -158,6 +158,9 @@ BOOL CImageVideoDlg::OnInitDialog()
 {
 	CDialog::OnInitDialog();
 	m_RenderEngine.Attach(m_PicControl);
+#ifdef _DEBUG
+	_CrtSetBreakAlloc(6021);  // Set break allocation for debugging
+#endif
 	return TRUE; 
 }
 

--- a/SampleApp_CPP/IntelDocCap.cpp
+++ b/SampleApp_CPP/IntelDocCap.cpp
@@ -205,23 +205,23 @@ void CIntelDocCap::SetAsync(int *ParaA)
 void CIntelDocCap::OnCbnSelchangeComboIdcParam()
 {
 	CHECK_CMD0;
-	m_edit_DocCapConfValue.SetWindowText(RSMGet((int)m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel())).c_str()); 
+	m_edit_DocCapConfValue.SetWindowText(RSMGet(static_cast<int>(m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel()))).c_str());
 }
 
 void CIntelDocCap::OnBnClickedButtonIdcParamGet()
 {
 	CHECK_CMD0;
-	m_edit_DocCapConfValue.SetWindowText(RSMGet((int)m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel())).c_str()); 
+	m_edit_DocCapConfValue.SetWindowText(RSMGet(static_cast<int>(m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel()))).c_str());
 }
 
 std::wstring CIntelDocCap::RSMGet(int opcode)
 {
-	DWORD_PTR dpOpCode =  m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel());
-	wchar_t a[5];
+	int opCode = static_cast<int>(m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel()));
+	wchar_t a[_MAX_ITOSTR_BASE10_COUNT];
 	long status = 1;
 	CComBSTR outXml(L"");
 	//enable the secure methode '_itow_s' resolve the unsafe functions
-	_itow_s((int)dpOpCode, a, 10);
+	_itow_s(opCode, a, 10);
 	if ( !SC->cmdGet(SelectedScannerID,a, &outXml, Async, &status) )
 	{
 		if ( !Async )
@@ -264,19 +264,19 @@ std::wstring CIntelDocCap::RSMGet(int opcode)
 void CIntelDocCap::OnBnClickedButtonIdcParamSet()
 {
 	CHECK_CMD0;
-	DWORD_PTR dpOpCode =  m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel());
+	int opCode = static_cast<int>(m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel()));
 	CString csValue;
 	m_edit_DocCapConfValue.GetWindowText(csValue);
-	RSMSet((int)dpOpCode, csValue.GetBuffer(), wsSelectedDataType);
+	RSMSet(opCode, csValue.GetBuffer(), wsSelectedDataType);
 }
 
 void CIntelDocCap::OnBnClickedButtonIdcParamStore()
 {
 	CHECK_CMD0;
-	DWORD_PTR dpOpCode =  m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel());
+	int opCode = static_cast<int>(m_cmbDocCapConf.GetItemData(m_cmbDocCapConf.GetCurSel()));
 	CString csValue;
 	m_edit_DocCapConfValue.GetWindowText(csValue);
-	RSMSet((int)dpOpCode, csValue.GetBuffer(), wsSelectedDataType, true);
+	RSMSet(opCode, csValue.GetBuffer(), wsSelectedDataType, true);
 }
 
 int CIntelDocCap::RSMSet(int attribID, std::wstring value, wstring dataType, bool isStore)
@@ -286,7 +286,7 @@ int CIntelDocCap::RSMSet(int attribID, std::wstring value, wstring dataType, boo
 	
 	LONG status = -1;
 
-	wchar_t buff[10];
+	wchar_t buff[_MAX_ITOSTR_BASE10_COUNT];
 	//enable the secure methode '_itow_s' resolve the unsafe functions
 	_itow_s(attribID, buff, 10);
 	CString AttribID = buff;

--- a/SampleApp_CPP/LogsDlg.cpp
+++ b/SampleApp_CPP/LogsDlg.cpp
@@ -111,8 +111,8 @@ void CLogsDlg::UpdateResults(CString& result)
     CString ExistingText;
     txtResultLog.GetWindowTextW(ExistingText);
 
-    wchar_t buf[8];
-    _itow_s(++m_Count, buf, 8, 10);
+    wchar_t buf[_MAX_ITOSTR_BASE10_COUNT];
+    _itow_s(++m_Count, buf, 10);
 
     ExistingText.Append(buf);
     ExistingText.Append(L". ");

--- a/SampleApp_CPP/QuickXmlParser.cpp
+++ b/SampleApp_CPP/QuickXmlParser.cpp
@@ -32,27 +32,26 @@ BSTR CQuickXmlParser::LoadXmlFile(LPTSTR XmlFilePath )
 	char* Buffer = 0;
 
 	hConfigXml = CreateFile(XmlFilePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
-	if(hConfigXml == INVALID_HANDLE_VALUE ) goto end;
+	if(hConfigXml != INVALID_HANDLE_VALUE)
+	{
+		dwReadBufferSize = GetFileSize(hConfigXml, NULL);
+		if (dwReadBufferSize != INVALID_FILE_SIZE)
+		{
+			Buffer = new char[dwReadBufferSize + 8];
 
-	dwReadBufferSize = GetFileSize(hConfigXml, NULL);
-	if(dwReadBufferSize == INVALID_FILE_SIZE) goto end;
-
-	Buffer = new char[dwReadBufferSize + 8];
-
-	ret = ReadFile(hConfigXml, Buffer, dwReadBufferSize + 8, &dwRead, NULL);
-	if((ret && dwRead) == 0) goto end;
-	
-
-	LPWSTR pszDest = new WCHAR[dwRead];
-	::MultiByteToWideChar( CP_THREAD_ACP, 0, Buffer, dwRead, pszDest, dwRead );
-	bs = SysAllocStringLen(pszDest, dwRead);
-	delete [] Buffer;
-	delete [] pszDest;
-
-end:
+			ret = ReadFile(hConfigXml, Buffer, dwReadBufferSize + 8, &dwRead, NULL);
+			if (ret && (dwRead > 0))
+			{
+				LPWSTR pszDest = new WCHAR[dwRead];
+				::MultiByteToWideChar(CP_THREAD_ACP, 0, Buffer, dwRead, pszDest, dwRead);
+				bs = SysAllocStringLen(pszDest, dwRead);
+				delete[] pszDest;
+			}
+			delete[] Buffer;
+		}
+	}
 	CloseHandle(hConfigXml);
 	return bs;
-
 }
 
 void CQuickXmlParser::Clear()

--- a/SampleApp_CPP/RTADlg.cpp
+++ b/SampleApp_CPP/RTADlg.cpp
@@ -223,7 +223,9 @@ void CRTADlg::UpdateRtaEvent(BSTR rtaData)
 		//OnGetRTAEventStatus(); //Update the RTAEventsGrid
 	}
 	catch (exception ex) {
-		LOG(-1, "Update RTA Event Error: {}",ex);
+		CString errorMsg;
+		errorMsg.Format(L"Update RTA Event Error: {%S}", ex.what());
+		LOGV(-1, errorMsg.GetBuffer());
 	}
 
 }
@@ -254,7 +256,9 @@ void CRTADlg::OnCheckedSuspendReportingAlerts()
 		GetTabManager().GetTabDlg<CLogsDlg>().DisplayResult(0, logStr);
 	}
 	catch (exception ex) {
-		LOG(-1, "RTA_SUSPEND_STATE_UPDATE_ERROR: {}", ex);
+		CString errorMsg;
+		errorMsg.Format(L"RTA_SUSPEND_STATE_UPDATE_ERROR: {%S}", ex.what());
+		LOGV(-1, errorMsg.GetBuffer());
 		throw ex;
 	}
 }
@@ -683,7 +687,9 @@ void CRTADlg::OnClearEventLog()
 		RtaEventLogGridControl.DeleteAllItems(); //Clearing the RTA Event Log
 	}
 	catch (exception ex) {
-		LOG(-1, "RTA_EVENT_LOG_CLEAR ERROR : {}", ex)
+		CString errorMsg;
+		errorMsg.Format(L"RTA_EVENT_LOG_CLEAR ERROR : {%S}", ex.what());
+		LOGV(-1, errorMsg.GetBuffer());
 	}
 	
 }
@@ -796,7 +802,7 @@ vector<vector<wstring>> CRTADlg::GetRTAEventsStatus() { //Parse the outXML of RT
 	}
 	catch (const exception& ex) {
 		// Handle exceptions
-		throw;
+		throw ex;
 	}
 
 	return eventDetailsList;
@@ -848,6 +854,7 @@ BOOL CRTADlg::GetRTASuspendStatus() //Parse the outXML of RTA State
 		LOG(status, "GET_RTA_SUSPEND_ERROR");
 		throw ex;
 	}
+	return FALSE;
 }
 
 void CRTADlg::UpdateRTAGrid(vector<vector<wstring>> eventDetailsList)
@@ -868,7 +875,7 @@ void CRTADlg::UpdateRTAGrid(vector<vector<wstring>> eventDetailsList)
 
 			// Set the subitem texts for the subsequent columns
 			for (size_t colIndex = 0; colIndex < event.size(); ++colIndex) {
-				RtaEventsGrid.SetItemText(nIndex, colIndex + 1, event[colIndex].c_str());
+				RtaEventsGrid.SetItemText(nIndex, (int) (colIndex + 1), event[colIndex].c_str());
 			}
 		}
 	}

--- a/SampleApp_CPP/RTADlg.cpp
+++ b/SampleApp_CPP/RTADlg.cpp
@@ -875,7 +875,7 @@ void CRTADlg::UpdateRTAGrid(vector<vector<wstring>> eventDetailsList)
 
 			// Set the subitem texts for the subsequent columns
 			for (size_t colIndex = 0; colIndex < event.size(); ++colIndex) {
-				RtaEventsGrid.SetItemText(nIndex, (int) (colIndex + 1), event[colIndex].c_str());
+				RtaEventsGrid.SetItemText(nIndex, static_cast<int>(colIndex + 1), event[colIndex].c_str());
 			}
 		}
 	}

--- a/SampleApp_CPP/RsmList.cpp
+++ b/SampleApp_CPP/RsmList.cpp
@@ -33,31 +33,31 @@ BOOL CRsmListCtrl::OnClickListView(NMHDR *pNMHDR, LRESULT *pResult)
 	CString sEditVal;
 	LPNMLISTVIEW p = (LPNMLISTVIEW)pNMHDR;
 
-	if(p->iItem == -1) goto End; //Clicked on a header ctrl
-	if(m_EditInfo.m_pEdit != 0)
+	if(p->iItem != -1) // Only if a list item
 	{
-		m_EditInfo.m_pEdit->GetWindowText(sEditVal);
-		SetItemText(m_EditInfo.m_Item, m_EditInfo.m_SubItem, sEditVal);
-		StopEdit();
-	}
-
-	if(p->iSubItem == 3)
-	{
-		GetSubItemRect(p->iItem, p->iSubItem, LVIR_BOUNDS, rec);
-		if(m_EditInfo.m_pEdit == 0)
+		if (m_EditInfo.m_pEdit != 0)
 		{
-			m_EditInfo.m_pEdit = new CEditText();
-			m_EditInfo.m_pEdit->Create(WS_CHILD | WS_VISIBLE | WS_BORDER | ES_CENTER, rec, this, 999);
-			m_EditInfo.m_pEdit->SetWindowText(GetItemText(p->iItem, p->iSubItem));
-			m_EditInfo.m_pEdit->SetSel(0, -1);
-			m_EditInfo.m_pEdit->SetFocus();
+			m_EditInfo.m_pEdit->GetWindowText(sEditVal);
+			SetItemText(m_EditInfo.m_Item, m_EditInfo.m_SubItem, sEditVal);
+			StopEdit();
 		}
 
-		m_EditInfo.m_Item = p->iItem;
-		m_EditInfo.m_SubItem = p->iSubItem;
-	}
+		if (p->iSubItem == 3)
+		{
+			GetSubItemRect(p->iItem, p->iSubItem, LVIR_BOUNDS, rec);
+			if (m_EditInfo.m_pEdit == 0)
+			{
+				m_EditInfo.m_pEdit = new CEditText();
+				m_EditInfo.m_pEdit->Create(WS_CHILD | WS_VISIBLE | WS_BORDER | ES_CENTER, rec, this, 999);
+				m_EditInfo.m_pEdit->SetWindowText(GetItemText(p->iItem, p->iSubItem));
+				m_EditInfo.m_pEdit->SetSel(0, -1);
+				m_EditInfo.m_pEdit->SetFocus();
+			}
 
-End:
+			m_EditInfo.m_Item = p->iItem;
+			m_EditInfo.m_SubItem = p->iSubItem;
+		}
+	}
 	*pResult = 0;
 	return FALSE;
 }

--- a/SampleApp_CPP/RtaList.cpp
+++ b/SampleApp_CPP/RtaList.cpp
@@ -301,17 +301,17 @@ void CRtaListCtrl::OnCustomDraw(NMHDR* pNMHDR, LRESULT* pResult)
 
     case CDDS_ITEMPREPAINT | CDDS_SUBITEM:
         // Check if the current subitem is in a checkbox column
-        if (IsCheckboxColumn(pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem))
+        if (IsCheckboxColumn(static_cast<int>(pLVCD->nmcd.dwItemSpec), pLVCD->iSubItem))
         {
             // Get a device context (DC) from the custom draw structure
             CDC* pDC = CDC::FromHandle(pLVCD->nmcd.hdc);
             CRect rect;
 
             // Get the rectangle area of the subitem
-            GetSubItemRect(pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem, LVIR_LABEL, rect);
+            GetSubItemRect(static_cast<int>(pLVCD->nmcd.dwItemSpec), pLVCD->iSubItem, LVIR_LABEL, rect);
 
             // Draw the checkbox in the subitem's rectangle
-            DrawCheckbox(pDC, this, pLVCD->nmcd.dwItemSpec, pLVCD->iSubItem, rect);
+            DrawCheckbox(pDC, this, static_cast<int>(pLVCD->nmcd.dwItemSpec), pLVCD->iSubItem, rect);
 
             // Skip the default drawing for this subitem (since we've custom drawn it)
             *pResult = CDRF_SKIPDEFAULT;

--- a/SampleApp_CPP/ScanToConnectDlg.cpp
+++ b/SampleApp_CPP/ScanToConnectDlg.cpp
@@ -54,6 +54,7 @@ CScanToConnectDlg::CScanToConnectDlg(CWnd* pParent /*=NULL*/)
 
 CScanToConnectDlg::~CScanToConnectDlg()
 {
+	ClearImageCache();
 }
 
 void CScanToConnectDlg::DoDataExchange(CDataExchange* pDX)

--- a/SampleApp_CPP/ScanToConnectDlg.cpp
+++ b/SampleApp_CPP/ScanToConnectDlg.cpp
@@ -178,7 +178,7 @@ void CScanToConnectDlg::RequestPairingBarcode()
 	}
 
 
-	SC->cmdGetBluetoothPairingBarcode(SelectedScannerID, Async, &status, protocol,(int) m_cmbDefaultOption.GetItemData(m_cmbDefaultOption.GetCurSel()),(int) m_cmbImageSize.GetItemData(m_cmbImageSize.GetCurSel()), L"");
+	SC->cmdGetBluetoothPairingBarcode(SelectedScannerID, Async, &status, protocol, static_cast<int>(m_cmbDefaultOption.GetItemData(m_cmbDefaultOption.GetCurSel())), static_cast<int>(m_cmbImageSize.GetItemData(m_cmbImageSize.GetCurSel())), L"");
 	LOG(status, "GET_PAIRING_BARCODE");
 }
 

--- a/SampleApp_CPP/ScannerActionDlg.cpp
+++ b/SampleApp_CPP/ScannerActionDlg.cpp
@@ -177,7 +177,7 @@ void CScannerActionDlg::OnLEDOn()
     CHECK_CMD0;
 
     SCANNER* p = GetMainDlg()->GetScannerInfo(SelectedScannerID);
-    int inSel = (int) CmbLED.GetItemData(CmbLED.GetCurSel());
+    int inSel = static_cast<int>(CmbLED.GetItemData(CmbLED.GetCurSel()));
     long status = 1;
     SC->cmdLED(SelectedScannerID, ScannerLEDTypes[inSel], Async, &status,p);
     LOG(status, "LED_ON");
@@ -188,7 +188,7 @@ void CScannerActionDlg::OnLEDOff()
     CHECK_CMD0;
 
     SCANNER* p = GetMainDlg()->GetScannerInfo(SelectedScannerID);
-    int inSel = (int) CmbLED.GetItemData(CmbLED.GetCurSel());
+    int inSel = static_cast<int>(CmbLED.GetItemData(CmbLED.GetCurSel()));
     long status = 1;
     SC->cmdLEDOff(SelectedScannerID, ScannerLEDTypes[inSel + 1], Async, &status,p);
     LOG(status, "LED_OFF");
@@ -198,11 +198,11 @@ void CScannerActionDlg::OnBeep()
 {
     CHECK_CMD0;
 
-    int val = (int) m_cmbBeeps.GetItemData(m_cmbBeeps.GetCurSel());
+    int val = static_cast<int>(m_cmbBeeps.GetItemData(m_cmbBeeps.GetCurSel()));
     long status=1;
 
-    wchar_t buf[8];
-    _itow_s(val, buf, 8, 10);
+    wchar_t buf[_MAX_ITOSTR_BASE10_COUNT];
+    _itow_s(val, buf, 10);
     wstring str = buf;
     SC->cmdBeep(SelectedScannerID, str, Async, &status);
     LOG(status, "SOUND_BEEPER");

--- a/SampleApp_CPP/ScannerCommands.cpp
+++ b/SampleApp_CPP/ScannerCommands.cpp
@@ -125,6 +125,7 @@ long CScannerCommands::cmdOpen(SHORT ScannerTypes[TOTAL_SCANNER_TYPES],SHORT NOT
 		SafeArrayPutElement(pSA, &i, &ScannerTypes[i]);
 	}
 	hr = this->ScannerInterface->Open(0, pSA,NOTypes, Status);
+	SafeArrayDestroy(pSA);
 	return hr;
 }
 
@@ -147,6 +148,7 @@ long CScannerCommands::cmdDiscover(BSTR * outXml,long *Status)
 
 	hr = ScannerInterface->GetScanners(&NumScan,pSA,outXml,Status);
 	////OutputDebugStringW(*outXml);
+	SafeArrayDestroy(pSA);
 	return hr;
 }
 
@@ -404,7 +406,7 @@ long CScannerCommands::cmdCaptureImage(wstring ScannerID,int Async,long *Status)
 long CScannerCommands::cmdGetBluetoothPairingBarcode(wstring ScannerID,int Async,long *Status, int protocol, int defaultOption, int size, wstring FilePath)
 {
 	HRESULT hr = S_FALSE;
-	wchar_t tempBuffer[10];
+	wchar_t tempBuffer[_MAX_ITOSTR_BASE10_COUNT];
 	wstring inXml=L"<inArgs><cmdArgs><arg-int>3</arg-int><arg-int>";
 	//enable the secure methode '_itow_s' resolve the unsafe functions
 	_itow_s(protocol, tempBuffer, 10);
@@ -621,8 +623,8 @@ long CScannerCommands::cmdLEDOff(wstring ScannerID,wstring LED,int Async,long *S
 
 long CScannerCommands::cmdRegisterEvents(int nEvents,wstring strEventsIDs,long *Status)
 {
-	wchar_t buf[8];
-	_itow_s(nEvents, buf, 8, 10);
+	wchar_t buf[_MAX_ITOSTR_BASE10_COUNT];
+	_itow_s(nEvents, buf, 10);
 	HRESULT hr = S_FALSE;
 
 	BSTR outXml;
@@ -638,8 +640,8 @@ long CScannerCommands::cmdRegisterEvents(int nEvents,wstring strEventsIDs,long *
 
 long CScannerCommands::cmdUnRegisterEvents(int nEvents,wstring strEventsIDs,long *Status)
 {
-	wchar_t buf[8];
-	_itow_s(nEvents, buf, 8, 10);
+	wchar_t buf[_MAX_ITOSTR_BASE10_COUNT];
+	_itow_s(nEvents, buf, 10);
 	HRESULT hr = S_FALSE;
 
 	BSTR outXml;
@@ -803,9 +805,9 @@ long CScannerCommands::cmdEnableKeyboardEmulator(bool bEnable, int Async, long *
 long CScannerCommands::cmdSetKeyboardEmulatorLocale(int Lang, int Async, long *Status) //VRQW74
 {
 	BSTR outXml;
-	WCHAR Buf[8];
+	wchar_t Buf[_MAX_ITOSTR_BASE10_COUNT];
 
-	_itow_s(Lang, Buf, 8, 10);
+	_itow_s(Lang, Buf, 10);
 
 	wstring inXml = L"<inArgs><cmdArgs><arg-int>";
 	inXml.append(Buf);

--- a/SampleApp_CPP/ScannerCommands.cpp
+++ b/SampleApp_CPP/ScannerCommands.cpp
@@ -21,26 +21,26 @@
 
 IMPLEMENT_DYNAMIC(CScannerCommands, CCmdTarget)
 
-    CScannerCommands *CScannerCommands::m_pThis = 0;
+	CScannerCommands *CScannerCommands::m_pThis = 0;
 
 CScannerCommands::CScannerCommands()
 {
-    ScannerInterface = NULL;
-    m_dwCookie = 0;
-    cmdCreateInstance();
+	ScannerInterface = NULL;
+	m_dwCookie = 0;
+	cmdCreateInstance();
 }
 
 CScannerCommands::CScannerCommands(CScannerSDKSampleAppDlg * ParaAppDialog)
 {
-    m_AppDialog = ParaAppDialog;
-    ScannerInterface = NULL;
-    m_dwCookie = 0;
-    cmdCreateInstance();
+	m_AppDialog = ParaAppDialog;
+	ScannerInterface = NULL;
+	m_dwCookie = 0;
+	cmdCreateInstance();
 }
 
 CScannerCommands::~CScannerCommands()
 {
-    cmdDestroyInstance();
+	cmdDestroyInstance();
 }
 
 
@@ -50,1027 +50,1027 @@ END_MESSAGE_MAP()
 // CScannerCommands message handlers
 long CScannerCommands::cmdCreateInstance(void)
 {
-    HRESULT hr = S_FALSE;
-    //Create the Scanner COM object
-    hr = CoCreateInstance(CLSID_CCoreScanner, NULL, CLSCTX_ALL, IID_ICoreScanner, ((void**)&ScannerInterface));
-    COM_CHECK(hr);
+	HRESULT hr = S_FALSE;
+	//Create the Scanner COM object
+	hr = CoCreateInstance(CLSID_CCoreScanner, NULL, CLSCTX_ALL, IID_ICoreScanner, ((void**)&ScannerInterface));
+	COM_CHECK(hr);
 
-    if(ScannerInterface)
-    {
-        //Create an instance of the sink object to sink Core Scanner Events
-        ScannerEventSink = new CEventSink(m_AppDialog);
-        ScannerEventSinkUnknown = ScannerEventSink->GetIDispatch(FALSE);
-        //Advice or make a connection
-        BOOL stat = AfxConnectionAdvise(ScannerInterface, DIID__ICoreScannerEvents, ScannerEventSinkUnknown, TRUE, &m_dwCookie);
-    }
-    m_pThis = this;
-    return hr;
+	if(ScannerInterface)
+	{
+		//Create an instance of the sink object to sink Core Scanner Events
+		ScannerEventSink = new CEventSink(m_AppDialog);
+		ScannerEventSinkUnknown = ScannerEventSink->GetIDispatch(FALSE);
+		//Advice or make a connection
+		BOOL stat = AfxConnectionAdvise(ScannerInterface, DIID__ICoreScannerEvents, ScannerEventSinkUnknown, TRUE, &m_dwCookie);
+	}
+	m_pThis = this;
+	return hr;
 
 Error:
-    m_pThis = 0;
-    return hr;
+	m_pThis = 0;
+	return hr;
 
 }
 
 void CScannerCommands::cmdDestroyInstance()
 {
-    /*** If ever the CoreScanner Service becomes unresponsive when the application is
-    closed, a STATUS_ACCESS_VIOLATION is raised on this thread which is handled
-    by a Win32 exception handler. - VRQW74
-    ***/
-    _try
-    {
-        if(ScannerInterface)
-        {
-            if(m_dwCookie != 0 && ScannerEventSink)
-            {
-                BOOL stat = AfxConnectionUnadvise(ScannerInterface, DIID__ICoreScannerEvents, ScannerEventSinkUnknown, TRUE, m_dwCookie);
-                ScannerEventSink = NULL;
-                ScannerEventSink = 0;
-                m_dwCookie = 0;
-            }
-            ScannerInterface->Release();
-            ScannerInterface = 0;
-        }
-    }
-    _except( EXCEPTION_EXECUTE_HANDLER )
-    {
-    }
+	/*** If ever the CoreScanner Service becomes unresponsive when the application is
+	closed, a STATUS_ACCESS_VIOLATION is raised on this thread which is handled
+	by a Win32 exception handler. - VRQW74
+	***/
+	_try
+	{
+		if(ScannerInterface)
+		{
+			if(m_dwCookie != 0 && ScannerEventSink)
+			{
+				BOOL stat = AfxConnectionUnadvise(ScannerInterface, DIID__ICoreScannerEvents, ScannerEventSinkUnknown, TRUE, m_dwCookie);
+				delete ScannerEventSink;
+				ScannerEventSink = NULL;
+				m_dwCookie = 0;
+			}
+			ScannerInterface->Release();
+			ScannerInterface = 0;
+		}
+	}
+	_except( EXCEPTION_EXECUTE_HANDLER )
+	{
+	}
 }
 
 HRESULT CScannerCommands::Execute(LONG opcode, BSTR* inXML, BSTR* outXML, int Async, LONG* status)
 {
-    if(ScannerInterface == 0) return S_FALSE;
-    HRESULT hr = S_FALSE;
-    
-    if (Async)
-        hr = ScannerInterface->ExecCommandAsync(opcode, inXML, status);
-    else
-        hr = ScannerInterface->ExecCommand(opcode, inXML, outXML, status); //Force call this version if outXML has to be returned.
-    return hr;
+	if(ScannerInterface == 0) return S_FALSE;
+	HRESULT hr = S_FALSE;
+	
+	if (Async)
+		hr = ScannerInterface->ExecCommandAsync(opcode, inXML, status);
+	else
+		hr = ScannerInterface->ExecCommand(opcode, inXML, outXML, status); //Force call this version if outXML has to be returned.
+	return hr;
 }
 
 long CScannerCommands::cmdOpen(SHORT ScannerTypes[TOTAL_SCANNER_TYPES],SHORT NOTypes,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    SAFEARRAY* pSA = NULL;
-    SAFEARRAYBOUND bound[1];
-    bound[0].lLbound = 0;
-    bound[0].cElements = 8;
+	HRESULT hr = S_FALSE;
+	SAFEARRAY* pSA = NULL;
+	SAFEARRAYBOUND bound[1];
+	bound[0].lLbound = 0;
+	bound[0].cElements = 8;
 
-    pSA = SafeArrayCreate(VT_I2, 1, bound);
+	pSA = SafeArrayCreate(VT_I2, 1, bound);
 
-    for ( long i = 0; i < 8; i++ )
-    {
-        SafeArrayPutElement(pSA, &i, &ScannerTypes[i]);
-    }
-    hr = this->ScannerInterface->Open(0, pSA,NOTypes, Status);
-    return hr;
+	for ( long i = 0; i < 8; i++ )
+	{
+		SafeArrayPutElement(pSA, &i, &ScannerTypes[i]);
+	}
+	hr = this->ScannerInterface->Open(0, pSA,NOTypes, Status);
+	return hr;
 }
 
 long CScannerCommands::cmdClose(long *Status)
 {
-    HRESULT hr = S_FALSE;
-    hr = ScannerInterface->Close(0,Status);
-    return hr;
+	HRESULT hr = S_FALSE;
+	hr = ScannerInterface->Close(0,Status);
+	return hr;
 }
 
 long CScannerCommands::cmdDiscover(BSTR * outXml,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    SHORT NumScan=0;
-    SAFEARRAY* pSA = NULL;
-    SAFEARRAYBOUND bound[1];
-    bound[0].lLbound = 0;
-    bound[0].cElements = 255;
-    pSA = SafeArrayCreate(VT_I2, 1, bound);
+	HRESULT hr = S_FALSE;
+	SHORT NumScan=0;
+	SAFEARRAY* pSA = NULL;
+	SAFEARRAYBOUND bound[1];
+	bound[0].lLbound = 0;
+	bound[0].cElements = 255;
+	pSA = SafeArrayCreate(VT_I2, 1, bound);
 
-    hr = ScannerInterface->GetScanners(&NumScan,pSA,outXml,Status);
-    ////OutputDebugStringW(*outXml);
-    return hr;
+	hr = ScannerInterface->GetScanners(&NumScan,pSA,outXml,Status);
+	////OutputDebugStringW(*outXml);
+	return hr;
 }
 
 long CScannerCommands::cmdGetAll(wstring ScannerID,BSTR * outXml,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RSM_ATTR_GETALL, &input, outXml, Async, Status);
+	return Execute(RSM_ATTR_GETALL, &input, outXml, Async, Status);
 }
 
 long CScannerCommands::cmdAimOn(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    BSTR outXml;
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	BSTR outXml;
 
-    return Execute(DEVICE_AIM_ON, &input, &outXml, Async, Status);
+	return Execute(DEVICE_AIM_ON, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdAimOff(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    BSTR outXml;
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	BSTR outXml;
 
-    return Execute(DEVICE_AIM_OFF, &input, &outXml, Async, Status);
+	return Execute(DEVICE_AIM_OFF, &input, &outXml, Async, Status);
 }
 
 
 long CScannerCommands::cmdGetNext(wstring ScannerID,wstring AttribNo,BSTR * outXml,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list>");
-    inXml.append(AttribNo);
-    inXml.append(L"</attrib_list></arg-xml></cmdArgs></inArgs>");
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list>");
+	inXml.append(AttribNo);
+	inXml.append(L"</attrib_list></arg-xml></cmdArgs></inArgs>");
 
-    CComBSTR input = inXml.c_str();
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RSM_ATTR_GETNEXT, &input, outXml, Async, Status);
+	return Execute(RSM_ATTR_GETNEXT, &input, outXml, Async, Status);
 }
 
 long CScannerCommands::cmdExecute(DWORD nCmdID,wstring inXml,BSTR * outXml,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    CComBSTR input = inXml.c_str();
-    
-    return Execute(nCmdID, &input, outXml, Async, Status);
+	HRESULT hr = S_FALSE;
+	CComBSTR input = inXml.c_str();
+	
+	return Execute(nCmdID, &input, outXml, Async, Status);
 }
 
 long CScannerCommands::cmdGet(wstring ScannerID,wstring AttribNo,BSTR * outXml,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list>");
-    inXml.append(AttribNo);
-    inXml.append(L"</attrib_list></arg-xml></cmdArgs></inArgs>");
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list>");
+	inXml.append(AttribNo);
+	inXml.append(L"</attrib_list></arg-xml></cmdArgs></inArgs>");
 
-    CComBSTR input = inXml.c_str();
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RSM_ATTR_GET, &input, outXml, Async, Status);
+	return Execute(RSM_ATTR_GET, &input, outXml, Async, Status);
 }
 
 
 long CScannerCommands::cmdGetScanCapa(wstring ScannerID,BSTR * outXml,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    
-    CComBSTR input = inXml.c_str();
-    
-    return Execute(DEVICE_GET_SCANNER_CAPABILITIES, &input, outXml, Async, Status);
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	
+	CComBSTR input = inXml.c_str();
+	
+	return Execute(DEVICE_GET_SCANNER_CAPABILITIES, &input, outXml, Async, Status);
 }
 
 long CScannerCommands::cmdSwitchHostMode(wstring ScannerID, wstring HostMode, wstring SilentSwitch, wstring PermanantChange, int Async, long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-string>");
-    inXml.append(HostMode);
-    inXml.append(L"</arg-string><arg-bool>");
-    inXml.append(SilentSwitch);
-    inXml.append(L"</arg-bool><arg-bool>");
-    inXml.append(PermanantChange);
-    inXml.append(L"</arg-bool></cmdArgs></inArgs>");
-    BSTR outXml;
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-string>");
+	inXml.append(HostMode);
+	inXml.append(L"</arg-string><arg-bool>");
+	inXml.append(SilentSwitch);
+	inXml.append(L"</arg-bool><arg-bool>");
+	inXml.append(PermanantChange);
+	inXml.append(L"</arg-bool></cmdArgs></inArgs>");
+	BSTR outXml;
 
-    CComBSTR input = inXml.c_str();
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_SWITCH_HOST_MODE, &input, &outXml, Async, Status);
+	return Execute(DEVICE_SWITCH_HOST_MODE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdSCdcSHostMode(wstring HostMode, wstring SilentSwitch, wstring PermanantChange, int Async, long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml = L"<inArgs>";
-    inXml.append(L"<cmdArgs><arg-string>");
-    inXml.append(HostMode);
-    inXml.append(L"</arg-string><arg-bool>");
-    inXml.append(SilentSwitch);
-    inXml.append(L"</arg-bool><arg-bool>");
-    inXml.append(PermanantChange);
-    inXml.append(L"</arg-bool></cmdArgs></inArgs>");
-    BSTR outXml;
+	HRESULT hr = S_FALSE;
+	wstring inXml = L"<inArgs>";
+	inXml.append(L"<cmdArgs><arg-string>");
+	inXml.append(HostMode);
+	inXml.append(L"</arg-string><arg-bool>");
+	inXml.append(SilentSwitch);
+	inXml.append(L"</arg-bool><arg-bool>");
+	inXml.append(PermanantChange);
+	inXml.append(L"</arg-bool></cmdArgs></inArgs>");
+	BSTR outXml;
 
-    CComBSTR input = inXml.c_str();
+	CComBSTR input = inXml.c_str();
 
-    return Execute(SWITCH_CDC_DEVICES, &input, &outXml, Async, Status);
+	return Execute(SWITCH_CDC_DEVICES, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdUpdateFW(wstring ScannerID,wstring FilePath,int Async,long *Status, bool IsBulk)
 {
-    HRESULT hr = S_FALSE;
+	HRESULT hr = S_FALSE;
 
-    wstring BulkArgStr;
-    if(IsBulk == true)
-        BulkArgStr = L"<arg-int>2</arg-int>";
-    else
-        BulkArgStr = L"<arg-int>1</arg-int>";
+	wstring BulkArgStr;
+	if(IsBulk == true)
+		BulkArgStr = L"<arg-int>2</arg-int>";
+	else
+		BulkArgStr = L"<arg-int>1</arg-int>";
 
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-string>");
-    inXml.append(FilePath);
-    inXml.append(L"</arg-string>");
-    inXml.append(BulkArgStr);
-    inXml.append(L"</cmdArgs></inArgs>");
-    BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-string>");
+	inXml.append(FilePath);
+	inXml.append(L"</arg-string>");
+	inXml.append(BulkArgStr);
+	inXml.append(L"</cmdArgs></inArgs>");
+	BSTR outXml;
 
-    CComBSTR input = inXml.c_str();
+	CComBSTR input = inXml.c_str();
 
-    if(_wcsicmp(PathFindExtensionW(FilePath.c_str()), L".SCNPLG" ) == 0)
-        hr = Execute(DEVICE_UPDATE_FIRMWARE_FROM_PLUGIN, &input, &outXml, Async, Status);
-    else
-        hr = Execute(DEVICE_UPDATE_FIRMWARE, &input, &outXml, Async, Status);
+	if(_wcsicmp(PathFindExtensionW(FilePath.c_str()), L".SCNPLG" ) == 0)
+		hr = Execute(DEVICE_UPDATE_FIRMWARE_FROM_PLUGIN, &input, &outXml, Async, Status);
+	else
+		hr = Execute(DEVICE_UPDATE_FIRMWARE, &input, &outXml, Async, Status);
 
-    return hr;
+	return hr;
 }
 
 long CScannerCommands::cmdUpdateAttribMeta(wstring ScannerID,wstring MetaFilePath,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-string>");
-    inXml.append(MetaFilePath);
-    inXml.append(L"</arg-string></cmdArgs></inArgs>");
-    BSTR outXml;
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-string>");
+	inXml.append(MetaFilePath);
+	inXml.append(L"</arg-string></cmdArgs></inArgs>");
+	BSTR outXml;
 
-    CComBSTR input = inXml.c_str();
+	CComBSTR input = inXml.c_str();
 
-    return Execute(UPDATE_ATTRIB_META_FILE, &input, &outXml, Async, Status);
+	return Execute(UPDATE_ATTRIB_META_FILE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdUpdateFWAbort(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_ABORT_UPDATE_FIRMWARE, &input, &outXml, Async, Status);
+	return Execute(DEVICE_ABORT_UPDATE_FIRMWARE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdFlushMacroPdf(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_FLUSH_MACROPDF, &input, &outXml, Async, Status);
+	return Execute(DEVICE_FLUSH_MACROPDF, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdAbortMacroPdf(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_ABORT_MACROPDF, &input, &outXml, Async, Status);
+	return Execute(DEVICE_ABORT_MACROPDF, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdPullTrigger(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_PULL_TRIGGER, &input, &outXml, Async, Status);
+	return Execute(DEVICE_PULL_TRIGGER, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdReleaseTrigger(wstring ScannerID, int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_RELEASE_TRIGGER, &input, &outXml, Async, Status);
+	return Execute(DEVICE_RELEASE_TRIGGER, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdStartNewFW(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(START_NEW_FIRMWARE, &input, &outXml, Async, Status);
+	return Execute(START_NEW_FIRMWARE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdCaptureImage(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
-    
-    return Execute(DEVICE_CAPTURE_IMAGE, &input, &outXml, Async, Status);
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
+	
+	return Execute(DEVICE_CAPTURE_IMAGE, &input, &outXml, Async, Status);
 }
 
 
 long CScannerCommands::cmdGetBluetoothPairingBarcode(wstring ScannerID,int Async,long *Status, int protocol, int defaultOption, int size, wstring FilePath)
 {
-    HRESULT hr = S_FALSE;
-    wchar_t tempBuffer[10];
-    wstring inXml=L"<inArgs><cmdArgs><arg-int>3</arg-int><arg-int>";
-    //enable the secure methode '_itow_s' resolve the unsafe functions
-    _itow_s(protocol, tempBuffer, 10);
-    inXml.append(tempBuffer);
-    inXml.append(L",");
-    _itow_s(defaultOption, tempBuffer, 10);
-    inXml.append(tempBuffer);
-    inXml.append(L",");
-    _itow_s(size, tempBuffer, 10);
-    inXml.append(tempBuffer);
-    inXml.append(L"</arg-int></cmdArgs></inArgs>");
+	HRESULT hr = S_FALSE;
+	wchar_t tempBuffer[10];
+	wstring inXml=L"<inArgs><cmdArgs><arg-int>3</arg-int><arg-int>";
+	//enable the secure methode '_itow_s' resolve the unsafe functions
+	_itow_s(protocol, tempBuffer, 10);
+	inXml.append(tempBuffer);
+	inXml.append(L",");
+	_itow_s(defaultOption, tempBuffer, 10);
+	inXml.append(tempBuffer);
+	inXml.append(L",");
+	_itow_s(size, tempBuffer, 10);
+	inXml.append(tempBuffer);
+	inXml.append(L"</arg-int></cmdArgs></inArgs>");
 
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(GET_PAIRING_BARCODE, &input, &outXml, Async, Status);
+	return Execute(GET_PAIRING_BARCODE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdSetBarcodeMode(wstring ScannerID, int Async, long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_CAPTURE_BARCODE, &input, &outXml, Async, Status);
+	return Execute(DEVICE_CAPTURE_BARCODE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdCaptureVideo(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_CAPTURE_VIDEO, &input, &outXml, Async, Status);
+	return Execute(DEVICE_CAPTURE_VIDEO, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdAbortImageXfer(wstring ScannerID,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_ABORT_IMAGE_XFER, &input, &outXml, Async, Status);
+	return Execute(DEVICE_ABORT_IMAGE_XFER, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdGetScanSDKV(BSTR * outXml,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs></inArgs>";
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs></inArgs>";
+	CComBSTR input = inXml.c_str();
 
-    return Execute(GET_VERSION, &input, outXml, Async, Status);
+	return Execute(GET_VERSION, &input, outXml, Async, Status);
 }
 
 long CScannerCommands::cmdGetDevTopology(BSTR * outXml,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
+	HRESULT hr = S_FALSE;
 
-    wstring inXml=L"<inArgs></inArgs>";
-    CComBSTR input = inXml.c_str();
+	wstring inXml=L"<inArgs></inArgs>";
+	CComBSTR input = inXml.c_str();
 
-    return Execute(GET_DEVICE_TOPOLOGY, &input, outXml, Async, Status);
+	return Execute(GET_DEVICE_TOPOLOGY, &input, outXml, Async, Status);
 }
 
 long CScannerCommands::cmdSetParametersEx(wstring ScannerID, wstring ID, wstring Value, int Async, long *Status)
 {
-    HRESULT hr = S_FALSE;
-    
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>");
-    inXml.append(ID);
-    inXml.append(L"</id><datatype>B</datatype><value>");
-    inXml.append(Value);
-    inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
-    BSTR outXml;
+	HRESULT hr = S_FALSE;
+	
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>");
+	inXml.append(ID);
+	inXml.append(L"</id><datatype>B</datatype><value>");
+	inXml.append(Value);
+	inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
+	BSTR outXml;
 
-    CComBSTR input = inXml.c_str();
-    return Execute(DEVICE_SET_PARAMETERS, &input, &outXml, Async, Status);
+	CComBSTR input = inXml.c_str();
+	return Execute(DEVICE_SET_PARAMETERS, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdViewFinderParameter(wstring ScannerID, wstring VVFPara1, wstring VVFPara2, int Async, long *Status)
 {
-    HRESULT hr = S_FALSE;
+	HRESULT hr = S_FALSE;
 
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>");
-    inXml.append(VVFPara1);
-    inXml.append(L"</id><datatype>B</datatype><value>");
-    inXml.append(VVFPara2);
-    inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
-    BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>");
+	inXml.append(VVFPara1);
+	inXml.append(L"</id><datatype>B</datatype><value>");
+	inXml.append(VVFPara2);
+	inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
+	BSTR outXml;
 
-    CComBSTR input = inXml.c_str();
-    
-    return Execute(DEVICE_SET_PARAMETERS, &input, &outXml, Async, Status);
+	CComBSTR input = inXml.c_str();
+	
+	return Execute(DEVICE_SET_PARAMETERS, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdGetParameters(wstring ScannerID,wstring Parent,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-int>");
-    inXml.append(Parent);
-    inXml.append(L"</arg-int></cmdArgs></inArgs>");
-    BSTR outXml;
+	HRESULT hr = S_FALSE;
+	
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-int>");
+	inXml.append(Parent);
+	inXml.append(L"</arg-int></cmdArgs></inArgs>");
+	BSTR outXml;
 
-    CComBSTR input = inXml.c_str();
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_GET_PARAMETERS, &input, &outXml, Async, Status);
+	return Execute(DEVICE_GET_PARAMETERS, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdPagerMotor(wstring ScannerID, wstring duration, int Async, long *Status)
 {
-    BSTR outXml;
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>");
-    inXml.append(to_wstring( PAGER_MOTOR_ACTION));
-    inXml.append(L"</id><datatype>X</datatype><value>");
-    inXml.append(duration);
-    inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
+	BSTR outXml;
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>");
+	inXml.append(to_wstring( PAGER_MOTOR_ACTION));
+	inXml.append(L"</id><datatype>X</datatype><value>");
+	inXml.append(duration);
+	inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
 
-    CComBSTR input = inXml.c_str();
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RSM_ATTR_SET, &input, &outXml, Async, Status);
+	return Execute(RSM_ATTR_SET, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdBeep(wstring ScannerID,wstring BeepCode,int Async,long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-int>");
-    inXml.append(BeepCode);
-    inXml.append(L"</arg-int></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-int>");
+	inXml.append(BeepCode);
+	inXml.append(L"</arg-int></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(DEVICE_BEEP_CONTROL, &input, &outXml, Async, Status);
+	return Execute(DEVICE_BEEP_CONTROL, &input, &outXml, Async, Status);
 
 #if 0
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>6000</id><datatype>X</datatype><value>");
-    inXml.append(BeepCode);
-    inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>6000</id><datatype>X</datatype><value>");
+	inXml.append(BeepCode);
+	inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RSM_ATTR_SET, &input, &outXml, Async, Status);
+	return Execute(RSM_ATTR_SET, &input, &outXml, Async, Status);
 #endif
 
 }
 
 long CScannerCommands::cmdLED(wstring ScannerID,wstring LED,int Async,long *Status,SCANNER* p)
 {
-    HRESULT hr = S_FALSE;
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-int>");
-    inXml.append(LED);
-    inXml.append(L"</arg-int></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
-    if(NULL != p)
-    {
-        if(p->Model.Left(6).Compare(L"PL3300")==0)
-        {
-            return Execute(DEVICE_LED_ON, &input, &outXml, Async, Status);
-        }
-        else
-        {
-            return Execute(SET_ACTION, &input, &outXml, Async, Status);
-        }      
-    }
-    return S_FALSE;
+	HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-int>");
+	inXml.append(LED);
+	inXml.append(L"</arg-int></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
+	if(NULL != p)
+	{
+		if(p->Model.Left(6).Compare(L"PL3300")==0)
+		{
+			return Execute(DEVICE_LED_ON, &input, &outXml, Async, Status);
+		}
+		else
+		{
+			return Execute(SET_ACTION, &input, &outXml, Async, Status);
+		}      
+	}
+	return S_FALSE;
 }
 
 long CScannerCommands::cmdLEDOff(wstring ScannerID,wstring LED,int Async,long *Status,SCANNER* p)
 {
-    HRESULT hr = S_FALSE;
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-int>");
-    inXml.append(LED);
-    inXml.append(L"</arg-int></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();    
-    if(NULL != p)
-    {
-        if(p->Model.Left(6).Compare(L"PL3300")==0)
-        {
-            return Execute(DEVICE_LED_OFF, &input, &outXml, Async, Status);            
-        }
-        else
-        {
-            return Execute(SET_ACTION, &input, &outXml, Async, Status);            
-        }
-    }
-    return S_FALSE;    
+	HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-int>");
+	inXml.append(LED);
+	inXml.append(L"</arg-int></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();    
+	if(NULL != p)
+	{
+		if(p->Model.Left(6).Compare(L"PL3300")==0)
+		{
+			return Execute(DEVICE_LED_OFF, &input, &outXml, Async, Status);            
+		}
+		else
+		{
+			return Execute(SET_ACTION, &input, &outXml, Async, Status);            
+		}
+	}
+	return S_FALSE;    
 }
 
 long CScannerCommands::cmdRegisterEvents(int nEvents,wstring strEventsIDs,long *Status)
 {
-    wchar_t buf[8];
-    _itow_s(nEvents, buf, 8, 10);
-    HRESULT hr = S_FALSE;
+	wchar_t buf[8];
+	_itow_s(nEvents, buf, 8, 10);
+	HRESULT hr = S_FALSE;
 
-    BSTR outXml;
-    wstring inXml=L"<inArgs><cmdArgs><arg-int>";
-    inXml.append(buf);
-    inXml.append(L"</arg-int><arg-int>");
-    inXml.append(strEventsIDs);
-    inXml.append(L"</arg-int></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
+	BSTR outXml;
+	wstring inXml=L"<inArgs><cmdArgs><arg-int>";
+	inXml.append(buf);
+	inXml.append(L"</arg-int><arg-int>");
+	inXml.append(strEventsIDs);
+	inXml.append(L"</arg-int></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(REGISTER_FOR_EVENTS, &input, &outXml, 0, Status);
+	return Execute(REGISTER_FOR_EVENTS, &input, &outXml, 0, Status);
 }
 
 long CScannerCommands::cmdUnRegisterEvents(int nEvents,wstring strEventsIDs,long *Status)
 {
-    wchar_t buf[8];
-    _itow_s(nEvents, buf, 8, 10);
-    HRESULT hr = S_FALSE;
+	wchar_t buf[8];
+	_itow_s(nEvents, buf, 8, 10);
+	HRESULT hr = S_FALSE;
 
-    BSTR outXml;
-    wstring inXml=L"<inArgs><cmdArgs><arg-int>";
-    inXml.append(buf);
-    inXml.append(L"</arg-int><arg-int>");
-    inXml.append(strEventsIDs);
-    inXml.append(L"</arg-int></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
+	BSTR outXml;
+	wstring inXml=L"<inArgs><cmdArgs><arg-int>";
+	inXml.append(buf);
+	inXml.append(L"</arg-int><arg-int>");
+	inXml.append(strEventsIDs);
+	inXml.append(L"</arg-int></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(UNREGISTER_FOR_EVENTS, &input, &outXml, 0, Status);
+	return Execute(UNREGISTER_FOR_EVENTS, &input, &outXml, 0, Status);
 }
 
 long CScannerCommands::cmdSet(wstring ScannerID,wstring AttribList,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
+	HRESULT hr = S_FALSE;
 
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list>");
-    inXml.append(AttribList);
-    inXml.append(L"</attrib_list></arg-xml></cmdArgs></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list>");
+	inXml.append(AttribList);
+	inXml.append(L"</attrib_list></arg-xml></cmdArgs></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RSM_ATTR_SET, &input, &outXml, Async, Status);
+	return Execute(RSM_ATTR_SET, &input, &outXml, Async, Status);
 
 }
 
 long CScannerCommands::cmdStore(wstring ScannerID,wstring AttribList,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
+	HRESULT hr = S_FALSE;
 
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list>");
-    inXml.append(AttribList);
-    inXml.append(L"</attrib_list></arg-xml></cmdArgs></inArgs>");
-    BSTR outXml;
-    CComBSTR input = inXml.c_str();
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list>");
+	inXml.append(AttribList);
+	inXml.append(L"</attrib_list></arg-xml></cmdArgs></inArgs>");
+	BSTR outXml;
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RSM_ATTR_STORE, &input, &outXml, Async, Status);
+	return Execute(RSM_ATTR_STORE, &input, &outXml, Async, Status);
 
 }
 
 long CScannerCommands::cmdReboot(wstring ScannerID,int Async,long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(REBOOT_SCANNER, &input, &outXml, Async, Status);
+	return Execute(REBOOT_SCANNER, &input, &outXml, Async, Status);
 
 }
 
 long CScannerCommands::cmdDisconnect(wstring ScannerID,int Async,long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
-    
-    return Execute(DISCONNECT_BT_SCANNER, &input, &outXml, Async, Status);
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	
+	return Execute(DISCONNECT_BT_SCANNER, &input, &outXml, Async, Status);
 
 }
 
 long CScannerCommands::cmdClaim(wstring ScannerID,int Async,long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(CLAIM_DEVICE, &input, &outXml, Async, Status);
+	return Execute(CLAIM_DEVICE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdSetParaDefault(wstring ScannerID,int Async,long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
-    
-    return Execute(DEVICE_SET_PARAMETER_DEFAULTS, &input, &outXml, Async, Status);
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	
+	return Execute(DEVICE_SET_PARAMETER_DEFAULTS, &input, &outXml, Async, Status);
 }
 
 
 long CScannerCommands::cmdSetParaPersistanceEx(wstring ScannerID,wstring ID, wstring Value,int Async,long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>");
-    inXml.append(ID);
-    inXml.append(L"</id><datatype>B</datatype><value>");
-    inXml.append(Value);
-    inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
-    BSTR outXml;
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>");
+	inXml.append(ID);
+	inXml.append(L"</id><datatype>B</datatype><value>");
+	inXml.append(Value);
+	inXml.append(L"</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>");
+	BSTR outXml;
 
-    CComBSTR input = inXml.c_str();
-    return Execute(DEVICE_SET_PARAMETER_PERSISTANCE, &input, &outXml, Async, Status);
+	CComBSTR input = inXml.c_str();
+	return Execute(DEVICE_SET_PARAMETER_PERSISTANCE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdRelease(wstring ScannerID,int Async,long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(RELEASE_DEVICE, &input, &outXml, Async, Status);
+	return Execute(RELEASE_DEVICE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdEnable(wstring ScannerID,int Async,long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(DEVICE_SCAN_ENABLE, &input, &outXml, Async, Status);
+	return Execute(DEVICE_SCAN_ENABLE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdDisable(wstring ScannerID,int Async,long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(DEVICE_SCAN_DISABLE, &input, &outXml, Async, Status);
+	return Execute(DEVICE_SCAN_DISABLE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdEnableKeyboardEmulator(bool bEnable, int Async, long *Status) //VRQW74
 {
-    BSTR outXml;
+	BSTR outXml;
 
-    wstring inXml = L"<inArgs><cmdArgs><arg-bool>";
-    bEnable == true ? inXml.append(L"true") : inXml.append(L"false");
-    inXml.append(L"</arg-bool></cmdArgs></inArgs>");
+	wstring inXml = L"<inArgs><cmdArgs><arg-bool>";
+	bEnable == true ? inXml.append(L"true") : inXml.append(L"false");
+	inXml.append(L"</arg-bool></cmdArgs></inArgs>");
 
-    CComBSTR input = inXml.c_str();
-    return Execute(KEYBOARD_EMULATOR_ENABLE, &input, &outXml, Async, Status);
+	CComBSTR input = inXml.c_str();
+	return Execute(KEYBOARD_EMULATOR_ENABLE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdSetKeyboardEmulatorLocale(int Lang, int Async, long *Status) //VRQW74
 {
-    BSTR outXml;
-    WCHAR Buf[8];
+	BSTR outXml;
+	WCHAR Buf[8];
 
-    _itow_s(Lang, Buf, 8, 10);
+	_itow_s(Lang, Buf, 8, 10);
 
-    wstring inXml = L"<inArgs><cmdArgs><arg-int>";
-    inXml.append(Buf);
-    inXml.append(L"</arg-int></cmdArgs></inArgs>");
+	wstring inXml = L"<inArgs><cmdArgs><arg-int>";
+	inXml.append(Buf);
+	inXml.append(L"</arg-int></cmdArgs></inArgs>");
 
-    CComBSTR input = inXml.c_str();
-    return Execute(KEYBOARD_EMULATOR_SET_LOCALE, &input, &outXml, Async, Status);
+	CComBSTR input = inXml.c_str();
+	return Execute(KEYBOARD_EMULATOR_SET_LOCALE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdGetKeyboardEmulatorConfig(bool& bEnable, int& Lang, int Async, long *Status) //VRQW74
 {
-    BSTR outXml;
-    wstring inXml = L"<inArgs></inArgs>";
-    CComBSTR input = inXml.c_str();
+	BSTR outXml;
+	wstring inXml = L"<inArgs></inArgs>";
+	CComBSTR input = inXml.c_str();
 
-    HRESULT hr = Execute(KEYBOARD_EMULATOR_GET_CONFIG, &input, &outXml, 0, Status); // Force Async = 0 since outXml returns stuff
-    if(hr == S_OK && outXml != NULL)
-    {
-        CQuickXmlParser x(outXml);
-        CQuickXmlParser::TAGDATA tag[2] = {0};
-        
-        tag[0].Tag.Name = L"KeyEnumState";
-        tag[1].Tag.Name = L"KeyEnumLocale";
+	HRESULT hr = Execute(KEYBOARD_EMULATOR_GET_CONFIG, &input, &outXml, 0, Status); // Force Async = 0 since outXml returns stuff
+	if(hr == S_OK && outXml != NULL)
+	{
+		CQuickXmlParser x(outXml);
+		CQuickXmlParser::TAGDATA tag[2] = {0};
+		
+		tag[0].Tag.Name = L"KeyEnumState";
+		tag[1].Tag.Name = L"KeyEnumLocale";
 
-        x.Configure(tag, 2);
-        
-        CQuickXmlParser::xptr p = 0;
-        p = x.Parse(p);
+		x.Configure(tag, 2);
+		
+		CQuickXmlParser::xptr p = 0;
+		p = x.Parse(p);
 
-        int state = _wtoi(x.Translate(tag[0].Value));
-        bEnable = (state == 1 ? true : false);
-        Lang = _wtoi(x.Translate(tag[1].Value));
-        
-        return S_OK;
-    }
-    else
-        return S_FALSE;
+		int state = _wtoi(x.Translate(tag[0].Value));
+		bEnable = (state == 1 ? true : false);
+		Lang = _wtoi(x.Translate(tag[1].Value));
+		
+		return S_OK;
+	}
+	else
+		return S_FALSE;
 
 }
 
 long CScannerCommands::cmdReadWeight(wstring ScannerID,BSTR * outXml, int Async, long *Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(SCALE_READ_WEIGHT, &input, outXml, Async, Status);
+	return Execute(SCALE_READ_WEIGHT, &input, outXml, Async, Status);
 }
 
 long CScannerCommands::cmdZeroScale(wstring ScannerID,int Async, long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(SCALE_ZERO_SCALE, &input, &outXml, Async, Status);
+	return Execute(SCALE_ZERO_SCALE, &input, &outXml, Async, Status);
 }
 
 long CScannerCommands::cmdRestScale(wstring ScannerID,int Async, long *Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(SCALE_SYSTEM_RESET, &input, &outXml, Async, Status);
+	return Execute(SCALE_SYSTEM_RESET, &input, &outXml, Async, Status);
 }
 // Update Decode Tone
 long CScannerCommands::cmdUpdateDecodeTone(wstring ScannerID, wstring FilePath, long* Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-string>");
-    inXml.append(FilePath);
-    inXml.append(L"</arg-string></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-string>");
+	inXml.append(FilePath);
+	inXml.append(L"</arg-string></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(UPDATE_DECODE_TONE, &input, &outXml, 0, Status);
+	return Execute(UPDATE_DECODE_TONE, &input, &outXml, 0, Status);
 }
 
 // Erase Decode Tone
 long CScannerCommands::cmdEraseDecodeTone(wstring ScannerID, long* Status)
 {
-    BSTR outXml;
-    wstring inXml=L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml=L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(ERASE_DECODE_TONE, &input, &outXml, 0, Status);
+	return Execute(ERASE_DECODE_TONE, &input, &outXml, 0, Status);
 }
 
 long CScannerCommands::cmdUploadElectricFenceCustomTone(wstring ScannerID, wstring FilePath, long* Status)
 {
-    BSTR outXml;
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-string>");
-    inXml.append(FilePath);
-    inXml.append(L"</arg-string></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-string>");
+	inXml.append(FilePath);
+	inXml.append(L"</arg-string></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(UPDATE_ELECTRIC_FENCE_CUSTOM_TONE, &input, &outXml, 0, Status);
+	return Execute(UPDATE_ELECTRIC_FENCE_CUSTOM_TONE, &input, &outXml, 0, Status);
 }
 
 long CScannerCommands::cmdEraseElectricFenceCustomTone(wstring ScannerID, long* Status)
 {
-    BSTR outXml;
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
-    HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
 
-    return Execute(ERASE_ELECTRIC_FENCE_CUSTOM_TONE, &input, &outXml, 0, Status);
+	return Execute(ERASE_ELECTRIC_FENCE_CUSTOM_TONE, &input, &outXml, 0, Status);
 }
 
 long CScannerCommands::cmdSetDADFSource(wstring Source, int Async, long *Status) //VRQW74
 {
-    BSTR outXml;
-    wstring inXml = L"<inArgs><cmdArgs><arg-string>";
-    inXml.append(Source);
-    inXml.append(L"</arg-string></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
+	BSTR outXml;
+	wstring inXml = L"<inArgs><cmdArgs><arg-string>";
+	inXml.append(Source);
+	inXml.append(L"</arg-string></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(CONFIGURE_DADF, &input, &outXml, Async, Status); 
+	return Execute(CONFIGURE_DADF, &input, &outXml, Async, Status); 
 }
 
 long CScannerCommands::cmdResetDADFSource(int Async, long *Status) //VRQW74
 {
-    BSTR outXml;
-    wstring inXml = L"<inArgs></inArgs>";
-    CComBSTR input = inXml.c_str();
+	BSTR outXml;
+	wstring inXml = L"<inArgs></inArgs>";
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RESET_DADF, &input, &outXml, Async, Status); 
+	return Execute(RESET_DADF, &input, &outXml, Async, Status); 
 }
 
 long CScannerCommands::cmdGetRTAEventStatus(wstring ScannerID, BSTR* outXml, long* Status)
 {
 
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RTA_GET_EVENT_STATUS, &input, outXml, 0, Status);
+	return Execute(RTA_GET_EVENT_STATUS, &input, outXml, 0, Status);
 
 }
 
 long CScannerCommands::cmdSetRTAEventStatus(wstring ScannerID, BSTR* outXml, long* Status, vector<vector<wstring>> events)
 {
 
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><rtaevent_list>");
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><rtaevent_list>");
 
-    for (const auto& rtaEvent : events)
-    {
-        
-            inXml.append(L"<rtaevent>");
-            inXml.append(L"<id>" + rtaEvent[0] + L"</id>");
-            inXml.append(L"<stat>" + rtaEvent[1] + L"</stat>");
-            inXml.append(L"<reported>" + to_wstring(rtaEvent[2] == L"TRUE" ? 1 : 0) + L"</reported>");
-            inXml.append(L"</rtaevent>");
-    }
+	for (const auto& rtaEvent : events)
+	{
+		
+			inXml.append(L"<rtaevent>");
+			inXml.append(L"<id>" + rtaEvent[0] + L"</id>");
+			inXml.append(L"<stat>" + rtaEvent[1] + L"</stat>");
+			inXml.append(L"<reported>" + to_wstring(rtaEvent[2] == L"TRUE" ? 1 : 0) + L"</reported>");
+			inXml.append(L"</rtaevent>");
+	}
 
-    inXml.append(L"</rtaevent_list></arg-xml></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
+	inXml.append(L"</rtaevent_list></arg-xml></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RTA_SET_EVENT_STATUS, &input, outXml, 0, Status);
+	return Execute(RTA_SET_EVENT_STATUS, &input, outXml, 0, Status);
 
 }
 
 long CScannerCommands::cmdUnregisterRTAEvent(wstring ScannerID, BSTR* outXml, long* Status, vector<vector<wstring>> events)
 {
 
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><rtaevent_list>");
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><rtaevent_list>");
 
-    for (const auto& rtaEvent : events)
-    {
+	for (const auto& rtaEvent : events)
+	{
 
-        inXml.append(L"<rtaevent>");
-        inXml.append(L"<id>" + rtaEvent[0] + L"</id>");
-        inXml.append(L"<stat>" + rtaEvent[1] + L"</stat>");
-        inXml.append(L"</rtaevent>");
-    }
+		inXml.append(L"<rtaevent>");
+		inXml.append(L"<id>" + rtaEvent[0] + L"</id>");
+		inXml.append(L"<stat>" + rtaEvent[1] + L"</stat>");
+		inXml.append(L"</rtaevent>");
+	}
 
-    inXml.append(L"</rtaevent_list></arg-xml></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
+	inXml.append(L"</rtaevent_list></arg-xml></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RTA_UNREGISTER_EVENTS, &input, outXml, 0, Status);
+	return Execute(RTA_UNREGISTER_EVENTS, &input, outXml, 0, Status);
 
 }
 
 long CScannerCommands::cmdSuspendRTAEvent(wstring ScannerID, BSTR* outXml, long* Status, BOOL status)
 {
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-bool>");
-    inXml.append(status ? L"true" : L"false");
-    inXml.append(L"</arg-bool></cmdArgs></inArgs>");
-    CComBSTR input = inXml.c_str();
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-bool>");
+	inXml.append(status ? L"true" : L"false");
+	inXml.append(L"</arg-bool></cmdArgs></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RTA_SUSPEND, &input, outXml, 0, Status);
+	return Execute(RTA_SUSPEND, &input, outXml, 0, Status);
 
 }
 
 long CScannerCommands::cmdGetRTAState(wstring ScannerID, BSTR* outXml, long* Status)
 {
 
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RTA_GETSTATE, &input, outXml, 0, Status);
+	return Execute(RTA_GETSTATE, &input, outXml, 0, Status);
 
 }
 
 long CScannerCommands::cmdGetSupportedRTAEvents(wstring ScannerID, BSTR* outXml, long* Status)
 {
-    HRESULT hr = S_FALSE;
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID></inArgs>");
-    CComBSTR input = inXml.c_str();
+	HRESULT hr = S_FALSE;
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID></inArgs>");
+	CComBSTR input = inXml.c_str();
 
-    return Execute(RTA_GET_SUPPORTED, &input, outXml, 0, Status);
+	return Execute(RTA_GET_SUPPORTED, &input, outXml, 0, Status);
 }
 
 long CScannerCommands::cmdRegisterRTAEvents(wstring ScannerID, long* Status, vector<vector<wstring>> eventDetailsList)
 {
-    HRESULT hr = S_FALSE;
-    BSTR outXml;
-    wstring inXml = L"<inArgs><scannerID>";
-    inXml.append(ScannerID);
-    inXml.append(L"</scannerID><cmdArgs><arg-xml><rtaevent_list>");
+	HRESULT hr = S_FALSE;
+	BSTR outXml;
+	wstring inXml = L"<inArgs><scannerID>";
+	inXml.append(ScannerID);
+	inXml.append(L"</scannerID><cmdArgs><arg-xml><rtaevent_list>");
 
-    for (const auto& eventDetails : eventDetailsList)
-    {
-        inXml.append(L"<rtaevent>")
-            .append(L"<id>").append(eventDetails[0]).append(L"</id>")
-            .append(L"<stat>").append(eventDetails[1]).append(L"</stat>")
-            .append(L"<onlimit>").append(eventDetails[2]).append(L"</onlimit>")
-            .append(L"<offlimit>").append(eventDetails[3]).append(L"</offlimit>")
-            .append(L"</rtaevent>");
-    }
+	for (const auto& eventDetails : eventDetailsList)
+	{
+		inXml.append(L"<rtaevent>")
+			.append(L"<id>").append(eventDetails[0]).append(L"</id>")
+			.append(L"<stat>").append(eventDetails[1]).append(L"</stat>")
+			.append(L"<onlimit>").append(eventDetails[2]).append(L"</onlimit>")
+			.append(L"<offlimit>").append(eventDetails[3]).append(L"</offlimit>")
+			.append(L"</rtaevent>");
+	}
 
-    // Complete the XML
-    inXml.append(L"</rtaevent_list></arg-xml></cmdArgs></inArgs>");
+	// Complete the XML
+	inXml.append(L"</rtaevent_list></arg-xml></cmdArgs></inArgs>");
 
-    // Convert the XML string to CComBSTR
-    CComBSTR input = inXml.c_str();
-    return Execute(RTA_REGISTER_EVENTS, &input, &outXml, 0, Status);
+	// Convert the XML string to CComBSTR
+	CComBSTR input = inXml.c_str();
+	return Execute(RTA_REGISTER_EVENTS, &input, &outXml, 0, Status);
 }

--- a/SampleApp_CPP/ScannerList.h
+++ b/SampleApp_CPP/ScannerList.h
@@ -59,7 +59,7 @@ public:
 		if(SelIndicesArray)
 		{
 			delete [] SelIndicesArray;
-			SelIndicesArray = 0;
+			SelIndicesArray = NULL;
 		}
 
 		UINT u = GetSelectedCount();
@@ -73,7 +73,7 @@ public:
 				nItem = GetNextItem(nItem, LVNI_SELECTED);
 				SelIndicesArray[i] = nItem;
 			}
-			SelIndicesArray[i] = -1;
+			SelIndicesArray[u] = -1; // using u instead of i fixes a warning
 		}
 		return SelIndicesArray;
 
@@ -81,7 +81,7 @@ public:
 
 	static int CALLBACK SortComp(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort)
 	{
-		return (int)(lParam2 - lParam1);
+		return static_cast<int>(lParam2 - lParam1);
 	}
 
 	void Sort()

--- a/SampleApp_CPP/ScannerSDKSampleApp.vcxproj
+++ b/SampleApp_CPP/ScannerSDKSampleApp.vcxproj
@@ -58,42 +58,42 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sonar|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='SCMRlease|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Sonar|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>Unicode</CharacterSet>
@@ -249,13 +249,13 @@ $(ProjectDir)Sonar.bat
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\CoreScanner\Common\includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -280,13 +280,13 @@ $(ProjectDir)Sonar.bat
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\CoreScanner\Common\includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -383,12 +383,12 @@ $(ProjectDir)Sonar.bat
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>false</MinimalRebuild>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -415,12 +415,12 @@ $(ProjectDir)Sonar.bat
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>false</MinimalRebuild>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/SampleApp_CPP/ScannerSDKSampleAppDlg.cpp
+++ b/SampleApp_CPP/ScannerSDKSampleAppDlg.cpp
@@ -242,38 +242,36 @@ SCANNER* CScannerSDKSampleAppDlg::GetScannerInfo(std::wstring ScannerID)
 
 void CScannerSDKSampleAppDlg::UpdateScannerStatus()
 {
-#pragma warning(disable:4311; disable:4312)
 
 	int ScannerCount = (int)m_ScannerMap.GetCount();
 	txtScannerSummary.Format(_T("Scanner Count=%d"), ScannerCount);
-	CMapStringToOb ScannerMap;
+	// Change to a type-safe map
+	CMap<CString, LPCTSTR, int, int> ScannerTypeCountMap;
 
-	CObject *count = 0;
-	int val;
 	int ID;
 	SCANNER sc;
 	POSITION pos = m_ScannerMap.GetStartPosition();
 	while(pos != NULL)
 	{
 		m_ScannerMap.GetNextAssoc(pos, ID, sc);
-		if(ScannerMap.Lookup(sc.Type, count) > 0)
+		int count = 0;	// moved count into while block
+		if(ScannerTypeCountMap.Lookup(sc.Type, count) > 0)
 		{
-			val = (int)count;
-			int new_val = val + 1;
-			ScannerMap.SetAt(sc.Type, (CObject*)new_val);
+			ScannerTypeCountMap[sc.Type] = count + 1;
 		}
 		else
-			ScannerMap.SetAt(sc.Type, (CObject*)(1));
+			ScannerTypeCountMap[sc.Type] = 1;
 	}
 
-	if(ScannerMap.GetCount() > 0)
+	if(ScannerTypeCountMap.GetCount() > 0)
 	{
-		CString Status, Temp;
-		pos = ScannerMap.GetStartPosition();
+		CString Status, Temp, scannerType;
+		int count;
+		pos = ScannerTypeCountMap.GetStartPosition();
 		while(pos != NULL)
 		{
-			ScannerMap.GetNextAssoc( pos, sc.Type, count );
-			Temp.Format(_T("   |   %s=%d"), sc.Type, (int)count);
+			ScannerTypeCountMap.GetNextAssoc( pos, scannerType, count );
+			Temp.Format(_T("   |   %s=%d"), scannerType, count);
 			Status += Temp;
 		}
 		txtScannerSummary += Status;
@@ -285,8 +283,6 @@ void CScannerSDKSampleAppDlg::UpdateScannerStatus()
 		GetTabManager().GetTabDlg<CRTADlg>().EnableWindow(FALSE);
 	}
 	UpdateData(0);
-
-#pragma warning(default:4311; disable:4312)
 }
 
 bool CScannerSDKSampleAppDlg::TranslateProtocolNames(SCANNER& Scanner, CString& TranslatedName, wchar_t *Name)

--- a/SampleApp_CPP/ScannerSDKSampleAppDlg.cpp
+++ b/SampleApp_CPP/ScannerSDKSampleAppDlg.cpp
@@ -243,7 +243,7 @@ SCANNER* CScannerSDKSampleAppDlg::GetScannerInfo(std::wstring ScannerID)
 void CScannerSDKSampleAppDlg::UpdateScannerStatus()
 {
 
-	int ScannerCount = (int)m_ScannerMap.GetCount();
+	int ScannerCount = static_cast<int>(m_ScannerMap.GetCount());
 	txtScannerSummary.Format(_T("Scanner Count=%d"), ScannerCount);
 	// Change to a type-safe map
 	CMap<CString, LPCTSTR, int, int> ScannerTypeCountMap;
@@ -271,7 +271,7 @@ void CScannerSDKSampleAppDlg::UpdateScannerStatus()
 		while(pos != NULL)
 		{
 			ScannerTypeCountMap.GetNextAssoc( pos, scannerType, count );
-			Temp.Format(_T("   |   %s=%d"), scannerType, count);
+			Temp.Format(_T("   |   %s=%d"), (LPCTSTR) scannerType, count);
 			Status += Temp;
 		}
 		txtScannerSummary += Status;


### PR DESCRIPTION
1) Memory leaks because delete was never called on the images containing a barcode. Both in ImageVideoDlg.cpp and in ScanToConnect.Dlg.cpp 2) Memory leak when the ScannerEventSink was being released. The pointer was assigned a NULL value but the memory itself was never deleted. That may be fine in C#, but not in C++. Also, the variable was assigned NULL (correct) and 0 (incorrect and redundant). 3) DWORD values were getting implicitly cast to ints. While this was acceptable since the values would always be within an int range, I added static_cast<int>() around the values to suppress the warnings. 4) Soon to be deprecated /Gm compile switch was removed. Multiprocessor build MP was enabled in its place. Unless a platform older than VS 2015 is to be used, this should be backward compatible.

This should resolve issue #12 